### PR TITLE
More specific error message on patch application failure.

### DIFF
--- a/src/Util/Misc.hs
+++ b/src/Util/Misc.hs
@@ -104,7 +104,7 @@ applyPatch origFilename patchFilename = do
     case ec of
         ExitSuccess -> return ()
         ExitFailure _ ->
-            hPutStrLn stderr "Failed patching the .cabal file" >> exitFailure
+            hPutStrLn stderr ("Failed patching "++origFilename++" with "++patchFilename) >> exitFailure
 
 applyPatchIfExist origFilename patchFilename =
     fileExist patchFilename >>= flip when (applyPatch origFilename patchFilename)


### PR DESCRIPTION
More specific error message (helpful when running cblrepo add -n on lots and you want to know _which_ one failed).
