### PR TITLE
Add descriptive error message when package version missing

### DIFF
--- a/src/Util/Misc.hs
+++ b/src/Util/Misc.hs
@@ -96,7 +96,7 @@ data Opts = Opts
 
 strPairArg s = let
         (s0, s1) = break (== ',') s
-    in return (s0, tail s1)
+    in if null s1 then error "Missing version" else return (s0, tail s1)
 strTripleArg s = let
         (s0, r1) = break (== ',') s
         (s1, r2) = break (== ',') (tail r1)


### PR DESCRIPTION
A really minor, minor thing that annoys me is when I forget to specify the package version when
adding a package the following happens:

$ cblrepo add foo
cblrepo: Prelude.tail: empty list

This pull request changes this behavior to:

$ cblrepo add foo
cblrepo: Missing version

I agree that this is just cosmetic, but it's an easy fix so there you go.
