### PR TITLE
Specify "staticlibs" option in PKGBUILD

### DIFF
--- a/src/Util/Translation.hs
+++ b/src/Util/Translation.hs
@@ -160,7 +160,7 @@ instance Pretty ArchPkg where
             , text "arch=('i686' 'x86_64')"
             , pretty makeDepends
             , pretty depends
-            , text "options=('strip')"
+            , text "options=('strip' 'staticlibs')"
             , pretty source
             , maybe empty pretty install
             , pretty sha256sums


### PR DESCRIPTION
"!staticlibs" has been set as default in makepkg.conf (see links
below). Haskell libraries are statically linked by default and
changing to dynamic linking will require some refactoring. So
currently it makes sense to explicitly specify "staticlibs" option
when generating a haskell PKGBUILD.

Notice that forcing "staticlibs" doesn't change the behavior because
it was the previous default option.

See:
https://projects.archlinux.org/devtools.git/commit/?id=0d16a9135055d0c998cac236608cb630c93f0ac7
http://www.haskell.org/pipermail/arch-haskell/2013-October/004592.html
http://www.haskell.org/pipermail/arch-haskell/2013-October/004593.html
